### PR TITLE
Add url field to Video record

### DIFF
--- a/lib/you_tube_scrapper/playlists/playlist.ex
+++ b/lib/you_tube_scrapper/playlists/playlist.ex
@@ -16,6 +16,6 @@ defmodule YouTubeScrapper.Playlists.Playlist do
   def changeset(playlist, attrs) do
     playlist
     |> cast(attrs, [:title, :link, :last_scraping])
-    |> validate_required([:title, :link, :last_scraping])
+    |> validate_required([:title, :link])
   end
 end

--- a/lib/you_tube_scrapper/playlists/video.ex
+++ b/lib/you_tube_scrapper/playlists/video.ex
@@ -9,6 +9,7 @@ defmodule YouTubeScrapper.Playlists.Video do
     field :title, :string
     field :duration, :string
     field :posted_on, :date
+    field :url, :string
     field :playlist_id, :binary_id
 
     timestamps(type: :utc_datetime)
@@ -17,7 +18,7 @@ defmodule YouTubeScrapper.Playlists.Video do
   @doc false
   def changeset(video, attrs) do
     video
-    |> cast(attrs, [:title, :duration, :description, :posted_on])
-    |> validate_required([:title, :duration, :description, :posted_on])
+    |> cast(attrs, [:title, :duration, :description, :posted_on, :url, :playlist_id])
+    |> validate_required([:title, :duration, :description, :posted_on, :url, :playlist_id])
   end
 end

--- a/lib/you_tube_scrapper_web/live/video_live/form_component.ex
+++ b/lib/you_tube_scrapper_web/live/video_live/form_component.ex
@@ -23,6 +23,7 @@ defmodule YouTubeScrapperWeb.VideoLive.FormComponent do
         <.input field={@form[:duration]} type="text" label="Duration" />
         <.input field={@form[:description]} type="text" label="Description" />
         <.input field={@form[:posted_on]} type="date" label="Posted on" />
+        <.input field={@form[:url]} type="text" label="URL" />
         <:actions>
           <.button phx-disable-with="Saving...">Save Video</.button>
         </:actions>

--- a/lib/you_tube_scrapper_web/live/video_live/index.html.heex
+++ b/lib/you_tube_scrapper_web/live/video_live/index.html.heex
@@ -16,6 +16,7 @@
   <:col :let={{_id, video}} label="Duration">{video.duration}</:col>
   <:col :let={{_id, video}} label="Description">{video.description}</:col>
   <:col :let={{_id, video}} label="Posted on">{video.posted_on}</:col>
+  <:col :let={{_id, video}} label="URL">{video.url}</:col>
   <:action :let={{_id, video}}>
     <div class="sr-only">
       <.link navigate={~p"/videos/#{video}"}>Show</.link>

--- a/lib/you_tube_scrapper_web/live/video_live/show.html.heex
+++ b/lib/you_tube_scrapper_web/live/video_live/show.html.heex
@@ -13,6 +13,7 @@
   <:item title="Duration">{@video.duration}</:item>
   <:item title="Description">{@video.description}</:item>
   <:item title="Posted on">{@video.posted_on}</:item>
+  <:item title="URL">{@video.url}</:item>
 </.list>
 
 <.back navigate={~p"/videos"}>Back to videos</.back>

--- a/priv/repo/migrations/20250115095851_add_url_to_videos.exs
+++ b/priv/repo/migrations/20250115095851_add_url_to_videos.exs
@@ -1,0 +1,9 @@
+defmodule YouTubeScrapper.Repo.Migrations.AddUrlToVideos do
+  use Ecto.Migration
+
+  def change do
+    alter table(:videos) do
+      add :url, :string
+    end
+  end
+end

--- a/test/support/fixtures/playlists_fixtures.ex
+++ b/test/support/fixtures/playlists_fixtures.ex
@@ -28,9 +28,10 @@ defmodule YouTubeScrapper.PlaylistsFixtures do
       attrs
       |> Enum.into(%{
         description: "some description",
-        duration: "some duration",
+        duration: "12:45",
         posted_on: ~D[2025-01-13],
-        title: "some title"
+        title: "some title",
+        url: "some url"
       })
       |> YouTubeScrapper.Playlists.create_video()
 

--- a/test/you_tube_scrapper/playlists_test.exs
+++ b/test/you_tube_scrapper/playlists_test.exs
@@ -71,7 +71,7 @@ defmodule YouTubeScrapper.PlaylistsTest do
   end
 
   describe "videos" do
-    @invalid_attrs %{description: nil, title: nil, duration: nil, posted_on: nil}
+    @invalid_attrs %{description: nil, title: nil, duration: nil, posted_on: nil, url: nil}
 
     test "list_videos/0 returns all videos" do
       video = video_fixture()
@@ -88,7 +88,8 @@ defmodule YouTubeScrapper.PlaylistsTest do
         description: "some description",
         title: "some title",
         duration: "some duration",
-        posted_on: ~D[2025-01-13]
+        posted_on: ~D[2025-01-13],
+        url: "some url"
       }
 
       assert {:ok, %Video{} = video} = Playlists.create_video(valid_attrs)
@@ -96,6 +97,7 @@ defmodule YouTubeScrapper.PlaylistsTest do
       assert video.title == "some title"
       assert video.duration == "some duration"
       assert video.posted_on == ~D[2025-01-13]
+      assert video.url == "some url"
     end
 
     test "create_video/1 with invalid data returns error changeset" do
@@ -109,7 +111,8 @@ defmodule YouTubeScrapper.PlaylistsTest do
         description: "some updated description",
         title: "some updated title",
         duration: "some updated duration",
-        posted_on: ~D[2025-01-14]
+        posted_on: ~D[2025-01-14],
+        url: "some updated url"
       }
 
       assert {:ok, %Video{} = video} = Playlists.update_video(video, update_attrs)
@@ -117,6 +120,7 @@ defmodule YouTubeScrapper.PlaylistsTest do
       assert video.title == "some updated title"
       assert video.duration == "some updated duration"
       assert video.posted_on == ~D[2025-01-14]
+      assert video.url == "some updated url"
     end
 
     test "update_video/2 with invalid data returns error changeset" do

--- a/test/you_tube_scrapper/playlists_test.exs
+++ b/test/you_tube_scrapper/playlists_test.exs
@@ -74,28 +74,33 @@ defmodule YouTubeScrapper.PlaylistsTest do
     @invalid_attrs %{description: nil, title: nil, duration: nil, posted_on: nil, url: nil}
 
     test "list_videos/0 returns all videos" do
-      video = video_fixture()
+      playlist = playlist_fixture()
+      video = video_fixture(%{playlist_id: playlist.id})
       assert Playlists.list_videos() == [video]
     end
 
     test "get_video!/1 returns the video with given id" do
-      video = video_fixture()
+      playlist = playlist_fixture()
+      video = video_fixture(%{playlist_id: playlist.id})
       assert Playlists.get_video!(video.id) == video
     end
 
     test "create_video/1 with valid data creates a video" do
+      playlist = playlist_fixture()
+
       valid_attrs = %{
         description: "some description",
         title: "some title",
-        duration: "some duration",
+        duration: "34:23",
         posted_on: ~D[2025-01-13],
-        url: "some url"
+        url: "some url",
+        playlist_id: playlist.id
       }
 
       assert {:ok, %Video{} = video} = Playlists.create_video(valid_attrs)
       assert video.description == "some description"
       assert video.title == "some title"
-      assert video.duration == "some duration"
+      assert video.duration == "34:23"
       assert video.posted_on == ~D[2025-01-13]
       assert video.url == "some url"
     end
@@ -105,7 +110,8 @@ defmodule YouTubeScrapper.PlaylistsTest do
     end
 
     test "update_video/2 with valid data updates the video" do
-      video = video_fixture()
+      playlist = playlist_fixture()
+      video = video_fixture(%{playlist_id: playlist.id})
 
       update_attrs = %{
         description: "some updated description",
@@ -124,19 +130,22 @@ defmodule YouTubeScrapper.PlaylistsTest do
     end
 
     test "update_video/2 with invalid data returns error changeset" do
-      video = video_fixture()
+      playlist = playlist_fixture()
+      video = video_fixture(%{playlist_id: playlist.id})
       assert {:error, %Ecto.Changeset{}} = Playlists.update_video(video, @invalid_attrs)
       assert video == Playlists.get_video!(video.id)
     end
 
     test "delete_video/1 deletes the video" do
-      video = video_fixture()
+      playlist = playlist_fixture()
+      video = video_fixture(%{playlist_id: playlist.id})
       assert {:ok, %Video{}} = Playlists.delete_video(video)
       assert_raise Ecto.NoResultsError, fn -> Playlists.get_video!(video.id) end
     end
 
     test "change_video/1 returns a video changeset" do
-      video = video_fixture()
+      playlist = playlist_fixture()
+      video = video_fixture(%{playlist_id: playlist.id})
       assert %Ecto.Changeset{} = Playlists.change_video(video)
     end
   end

--- a/test/you_tube_scrapper_web/live/video_live_test.exs
+++ b/test/you_tube_scrapper_web/live/video_live_test.exs
@@ -4,12 +4,25 @@ defmodule YouTubeScrapperWeb.VideoLiveTest do
   import Phoenix.LiveViewTest
   import YouTubeScrapper.PlaylistsFixtures
 
-  @create_attrs %{description: "some description", title: "some title", duration: "some duration", posted_on: "2025-01-13"}
-  @update_attrs %{description: "some updated description", title: "some updated title", duration: "some updated duration", posted_on: "2025-01-14"}
+  @create_attrs %{
+    description: "some description",
+    title: "some title",
+    duration: "some duration",
+    posted_on: "2025-01-13",
+    url: "some url"
+  }
+  @update_attrs %{
+    description: "some updated description",
+    title: "some updated title",
+    duration: "some updated duration",
+    posted_on: "2025-01-14",
+    url: "some updated url"
+  }
   @invalid_attrs %{description: nil, title: nil, duration: nil, posted_on: nil}
 
   defp create_video(_) do
-    video = video_fixture()
+    playlist = playlist_fixture()
+    video = video_fixture(%{playlist_id: playlist.id})
     %{video: video}
   end
 


### PR DESCRIPTION
This pull request includes several changes to the YouTubeScrapper application, primarily focusing on adding a new `url` field to the `Video` schema and updating related components and tests to accommodate this new field. Additionally, there is a minor change to the `Playlist` schema.

Schema updates:

* Added `url` field to the `Video` schema in `lib/you_tube_scrapper/playlists/video.ex` and updated the `changeset` function to include this new field. [[1]](diffhunk://#diff-54db4e5c7d807650d00ae3ab350a18ab35c4cb4fb30606d115d99eb06c5f45e4R12) [[2]](diffhunk://#diff-54db4e5c7d807650d00ae3ab350a18ab35c4cb4fb30606d115d99eb06c5f45e4L20-R22)
* Removed `:last_scraping` from the required fields in the `Playlist` schema in `lib/you_tube_scrapper/playlists/playlist.ex`.

Database migration:

* Added a migration file to add the `url` column to the `videos` table in `priv/repo/migrations/20250115095851_add_url_to_videos.exs`.

Frontend updates:

* Updated the video form component to include an input field for `url` in `lib/you_tube_scrapper_web/live/video_live/form_component.ex`.
* Updated the video index and show templates to display the `url` field in `lib/you_tube_scrapper_web/live/video_live/index.html.heex` and `lib/you_tube_scrapper_web/live/video_live/show.html.heex`. [[1]](diffhunk://#diff-529a859be8ec19e65bf27b0b5318a5e6cffc07d85a1bd76882502706c55a1a7cR19) [[2]](diffhunk://#diff-b77e3c41179682a7d0f51303c0c77d2379eae79fcca5803dd8fabf1a0b6f37b8R16)

Test updates:

* Updated video fixtures and tests to include the `url` field and ensure the `playlist_id` is set in `test/support/fixtures/playlists_fixtures.ex`, `test/you_tube_scrapper/playlists_test.exs`, and `test/you_tube_scrapper_web/live/video_live_test.exs`. [[1]](diffhunk://#diff-68ddd3f0c0c8112a238a87a7b94ac891a2b41aea8d90aeec6632670a44cb7cfeL31-R34) [[2]](diffhunk://#diff-442deeeb82025156c30b63d9b936bec8035944a505e2601f99676400fe31dc62L74-R148) [[3]](diffhunk://#diff-5d7727671c5567c3aeca96254429b3d8647c07259307a2873ad15a68f56e7b8bL7-R25)