### PR TITLE
Add scrapper function to save playlist and video records

### DIFF
--- a/lib/you_tube_scrapper/playlists.ex
+++ b/lib/you_tube_scrapper/playlists.ex
@@ -4,10 +4,11 @@ defmodule YouTubeScrapper.Playlists do
   """
 
   import Ecto.Query, warn: false
-
   alias YouTubeScrapper.Playlists.Playlist
   alias YouTubeScrapper.Playlists.Video
   alias YouTubeScrapper.Repo
+  alias Crawly
+  alias Floki
 
   @doc """
   Returns the list of playlists.
@@ -195,5 +196,48 @@ defmodule YouTubeScrapper.Playlists do
   """
   def change_video(%Video{} = video, attrs \\ %{}) do
     Video.changeset(video, attrs)
+  end
+
+  @doc """
+  Scrapes a YouTube playlist and saves the playlist and video records.
+
+  ## Examples
+
+      iex> scrape_playlist("https://www.youtube.com/playlist?list=PL12345")
+      :ok
+
+  """
+  def scrape_playlist(playlist_url) do
+    {:ok, response} = Crawly.fetch(playlist_url)
+    {:ok, document} = Floki.parse_document(response.body)
+
+    playlist_title = Floki.find(document, "h1#title")[0] |> Floki.text()
+    playlist = %Playlist{title: playlist_title, link: playlist_url}
+    {:ok, playlist} = Repo.insert(playlist)
+
+    video_elements = Floki.find(document, "ytd-playlist-video-renderer")
+    Enum.each(video_elements, fn video_element ->
+      video_title = Floki.find(video_element, "a#video-title")[0] |> Floki.text()
+      video_duration = Floki.find(video_element, "span#text")[0] |> Floki.text()
+      video_description = Floki.find(video_element, "yt-formatted-string#description-text")[0] |> Floki.text()
+      video_posted_on = Floki.find(video_element, "div#metadata-line span")[1] |> Floki.text()
+      video_url = Floki.find(video_element, "a#video-title")[0] |> Floki.attribute("href") |> List.first()
+
+      video = %Video{
+        title: video_title,
+        duration: video_duration,
+        description: video_description,
+        posted_on: Date.from_iso8601!(video_posted_on),
+        url: video_url,
+        playlist_id: playlist.id
+      }
+
+      Repo.insert(video)
+    end)
+
+    playlist = Ecto.Changeset.change(playlist, last_scraping: NaiveDateTime.utc_now())
+    Repo.update(playlist)
+
+    :ok
   end
 end

--- a/lib/you_tube_scrapper_web/live/scrape_live.ex
+++ b/lib/you_tube_scrapper_web/live/scrape_live.ex
@@ -1,0 +1,17 @@
+defmodule YouTubeScrapperWeb.ScrapeLive do
+  use YouTubeScrapperWeb, :live_view
+
+  alias YouTubeScrapper.Playlists
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, :videos, [])}
+  end
+
+  @impl true
+  def handle_event("scrape", %{"playlist_url" => playlist_url}, socket) do
+    Playlists.scrape_playlist(playlist_url)
+    videos = Playlists.list_videos() |> Enum.sort_by(& &1.posted_on)
+    {:noreply, assign(socket, :videos, videos)}
+  end
+end

--- a/lib/you_tube_scrapper_web/live/scrape_live.html.heex
+++ b/lib/you_tube_scrapper_web/live/scrape_live.html.heex
@@ -1,0 +1,16 @@
+<div>
+  <h1>Which video would you like to scrape?</h1>
+  <.simple_form for={:scrape} phx-submit="scrape">
+    <.input field={:playlist_url} type="text" label="YouTube Playlist URL" />
+    <:actions>
+      <.button>Scrape</.button>
+    </:actions>
+  </.simple_form>
+
+  <.table id="videos" rows={@videos}>
+    <:col :let={video} label="Title">{video.title}</:col>
+    <:col :let={video} label="Duration">{video.duration}</:col>
+    <:col :let={video} label="Description">{video.description}</:col>
+    <:col :let={video} label="Posted on">{video.posted_on}</:col>
+  </.table>
+</div>

--- a/lib/you_tube_scrapper_web/router.ex
+++ b/lib/you_tube_scrapper_web/router.ex
@@ -31,6 +31,8 @@ defmodule YouTubeScrapperWeb.Router do
 
     live "/videos/:id", VideoLive.Show, :show
     live "/videos/:id/show/edit", VideoLive.Show, :edit
+
+    live "/scrape", ScrapeLive, :index
   end
 
   # Other scopes may use custom stacks.

--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,9 @@ defmodule YouTubeScrapper.MixProject do
       {:gettext, "~> 0.26"},
       {:jason, "~> 1.2"},
       {:dns_cluster, "~> 0.1.1"},
-      {:bandit, "~> 1.5"}
+      {:bandit, "~> 1.5"},
+      {:crawly, "~> 0.13.0"},
+      {:floki, "~> 0.30.0"}
     ]
   end
 

--- a/test/you_tube_scrapper_web/live/scrape_live_test.exs
+++ b/test/you_tube_scrapper_web/live/scrape_live_test.exs
@@ -1,0 +1,25 @@
+defmodule YouTubeScrapperWeb.ScrapeLiveTest do
+  use YouTubeScrapperWeb.ConnCase, async: true
+  import Phoenix.LiveViewTest
+
+  alias YouTubeScrapper.Playlists
+
+  @valid_playlist_url "https://www.youtube.com/playlist?list=PL12345"
+
+  describe "ScrapeLive" do
+    test "renders the scrape form and scrapes videos", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/scrape")
+
+      assert has_element?(view, "h1", "Which video would you like to scrape?")
+      assert has_element?(view, "form[phx-submit=scrape]")
+
+      {:ok, _playlist} = Playlists.scrape_playlist(@valid_playlist_url)
+
+      send(view, :scrape, %{"playlist_url" => @valid_playlist_url})
+
+      assert has_element?(view, "table#videos")
+      assert has_element?(view, "td", "Video Title 1")
+      assert has_element?(view, "td", "Video Title 2")
+    end
+  end
+end


### PR DESCRIPTION
Related to #20

Add scrapper function and LiveView page for scraping YouTube playlists.

* **Scrapper Function**
  - Add `{:crawly, "~> 0.13.0"}` and `{:floki, "~> 0.30.0"}` to the dependencies in `mix.exs`.
  - Add `scrape_playlist/1` function in `lib/you_tube_scrapper/playlists.ex` to scrape YouTube playlists and save the required records.
  - Use Crawly and Floki libraries to scrape YouTube.

* **LiveView Page**
  - Create `ScrapeLive` module in `lib/you_tube_scrapper_web/live/scrape_live.ex` to handle the scraping process.
  - Create `scrape_live.html.heex` in `lib/you_tube_scrapper_web/live` to input the YouTube playlist link and display the scraped videos.
  - Add a new route for the scraping LiveView page in `lib/you_tube_scrapper_web/router.ex`.

* **Tests**
  - Add tests for the scrapper function and LiveView page in `test/you_tube_scrapper_web/live/scrape_live_test.exs`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JuliaMathias/youtube_scrapper/pull/21?shareId=70077fa4-e945-45c9-96fa-1763e63baca7).